### PR TITLE
Add Hover and Press animations for game cover images

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -86,7 +86,7 @@ const pageTitle = "Unblocked games";
                     alt="The Impossible Quiz 2 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">The impossible quiz 2</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">The Impossible Quiz 2</p>
             </a>
             <a href="/games/supermarioflash" class="game-tile">
                 <img
@@ -94,7 +94,7 @@ const pageTitle = "Unblocked games";
                     alt="Super Mario Flash cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Super mario flash</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Super Mario Flash</p>
             </a>
             <a href="/games/minesweeper" class="game-tile">
                 <img
@@ -134,7 +134,7 @@ const pageTitle = "Unblocked games";
                     alt="Happy Wheels cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Happy wheels</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Happy Wheels</p>
             </a>
             <a href="/games/geometry-dash" class="game-tile">
                 <img
@@ -142,7 +142,7 @@ const pageTitle = "Unblocked games";
                     alt="Geometry Dash cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Geometry dash</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Geometry Dash</p>
             </a>
             <a href="/games/madness-project-nexus" class="game-tile">
                 <img
@@ -150,7 +150,7 @@ const pageTitle = "Unblocked games";
                     alt="Madness: Project Nexus cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Madness: project nexus</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Madness: Project Nexus</p>
             </a>
             <a href="/games/riddle-school3" class="game-tile">
                 <img
@@ -158,7 +158,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 3 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 3</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 3</p>
             </a>
             <a href="/games/riddle-school4" class="game-tile">
                 <img
@@ -166,7 +166,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 4 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 4</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 4</p>
             </a>
             <a href="/games/riddle-school5" class="game-tile">
                 <img
@@ -174,7 +174,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 5 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 5</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 5</p>
             </a>
             <a href="/games/plants-vs-zombies" class="game-tile">
                 <img
@@ -182,7 +182,7 @@ const pageTitle = "Unblocked games";
                     alt="Plants vs Zombies cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Plants vs zombies</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Plants vs Zombies</p>
             </a>
             <a href="/games/geography-game" class="game-tile">
                 <img
@@ -190,7 +190,7 @@ const pageTitle = "Unblocked games";
                     alt="Geography Game cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Geography game USA</p>
+                <p class="hover:underline decoration-sky-500 decoration-3">Geography Game USA</p>
             </a>
         </div>
         <div

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,6 @@ const pageTitle = "Unblocked games";
             text-decoration: none;
             margin: 20px;
             display: inline-block;
-            overflow: hidden;
         }
         </style>
     </head>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,7 +27,7 @@ const pageTitle = "Unblocked games";
         .game-tile {
             text-align: center;
             text-decoration: none;
-            margin: 10px;
+            margin: 20px;
         }
         </style>
     </head>
@@ -43,7 +43,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/gm2cover.png"
                     alt="Gun mayhem 2 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3" >Gun Mayhem 2</p>
             </a>
@@ -52,7 +52,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/hobo2cover.jpg"
                     alt="Hobo 2 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Hobo 2</p>
             </a>
@@ -60,16 +60,15 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/Riddle-School-2_logo.png"
                     alt="Riddle School 2 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <br />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 2</p>
             </a>
             <a href="/games/vex3" class="game-tile">
                 <img
                     src="/images/vex-3cover.jpg"
                     alt="Vex 3 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Vex 3</p>
             </a>
@@ -77,7 +76,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/tetriscover.avif"
                     alt="Tetris cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Tetris</p>
             </a>
@@ -85,7 +84,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/impossiblequiz2cover.jpg"
                     alt="The Impossible Quiz 2 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">The impossible quiz 2</p>
             </a>
@@ -93,7 +92,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/supermarioflashcover.png"
                     alt="Super Mario Flash cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Super mario flash</p>
             </a>
@@ -101,7 +100,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/minesweepercover.jpg"
                     alt="Minesweeper cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Minesweeper</p>
             </a>
@@ -109,7 +108,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/bloonstd5cover.png"
                     alt="Bloons TD 5 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Bloons TD 5</p>
             </a>
@@ -117,7 +116,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/hobo7cover.webp"
                     alt="Hobo 7 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Hobo 7</p>
             </a>
@@ -125,7 +124,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/doomcover.jpg"
                     alt="Doom cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Doom</p>
             </a>
@@ -133,7 +132,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/happywheelscover.jpeg"
                     alt="Happy Wheels cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Happy wheels</p>
             </a>
@@ -141,7 +140,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/geometrydashcover.png"
                     alt="Geometry Dash cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Geometry dash</p>
             </a>
@@ -149,7 +148,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/madness-cover.png"
                     alt="Madness: Project Nexus cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Madness: project nexus</p>
             </a>
@@ -157,7 +156,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddle-school-3-cover.jpg"
                     alt="Riddle School 3 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 3</p>
             </a>
@@ -165,7 +164,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddle-school-4-cover.jpg"
                     alt="Riddle School 4 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 4</p>
             </a>
@@ -173,7 +172,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddleschool5-cover.jpg"
                     alt="Riddle School 5 cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 5</p>
             </a>
@@ -181,7 +180,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/plants-vs-zombies-cover.gif"
                     alt="Plants vs Zombies cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Plants vs zombies</p>
             </a>
@@ -189,7 +188,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/geography_game_cover.jpg"
                     alt="Geography Game cover image"
-                    class="cover-img rounded-xl"
+                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Geography game USA</p>
             </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/gm2cover.png"
                     alt="Gun mayhem 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3" >Gun Mayhem 2</p>
             </a>
@@ -52,7 +52,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/hobo2cover.jpg"
                     alt="Hobo 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Hobo 2</p>
             </a>
@@ -60,7 +60,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/Riddle-School-2_logo.png"
                     alt="Riddle School 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 2</p>
             </a>
@@ -68,7 +68,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/vex-3cover.jpg"
                     alt="Vex 3 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Vex 3</p>
             </a>
@@ -76,7 +76,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/tetriscover.avif"
                     alt="Tetris cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Tetris</p>
             </a>
@@ -84,7 +84,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/impossiblequiz2cover.jpg"
                     alt="The Impossible Quiz 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">The impossible quiz 2</p>
             </a>
@@ -92,7 +92,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/supermarioflashcover.png"
                     alt="Super Mario Flash cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Super mario flash</p>
             </a>
@@ -100,7 +100,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/minesweepercover.jpg"
                     alt="Minesweeper cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Minesweeper</p>
             </a>
@@ -108,7 +108,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/bloonstd5cover.png"
                     alt="Bloons TD 5 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Bloons TD 5</p>
             </a>
@@ -116,7 +116,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/hobo7cover.webp"
                     alt="Hobo 7 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Hobo 7</p>
             </a>
@@ -124,7 +124,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/doomcover.jpg"
                     alt="Doom cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Doom</p>
             </a>
@@ -132,7 +132,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/happywheelscover.jpeg"
                     alt="Happy Wheels cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Happy wheels</p>
             </a>
@@ -140,7 +140,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/geometrydashcover.png"
                     alt="Geometry Dash cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Geometry dash</p>
             </a>
@@ -148,7 +148,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/madness-cover.png"
                     alt="Madness: Project Nexus cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Madness: project nexus</p>
             </a>
@@ -156,7 +156,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddle-school-3-cover.jpg"
                     alt="Riddle School 3 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 3</p>
             </a>
@@ -164,7 +164,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddle-school-4-cover.jpg"
                     alt="Riddle School 4 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 4</p>
             </a>
@@ -172,7 +172,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddleschool5-cover.jpg"
                     alt="Riddle School 5 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle school 5</p>
             </a>
@@ -180,7 +180,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/plants-vs-zombies-cover.gif"
                     alt="Plants vs Zombies cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Plants vs zombies</p>
             </a>
@@ -188,7 +188,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/geography_game_cover.jpg"
                     alt="Geography Game cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-all duration-300 hover:shadow-lg active:scale-95 transform"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Geography game USA</p>
             </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,7 +47,7 @@ const pageTitle = "Unblocked games";
                     alt="Gun mayhem 2 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3" >Gun Mayhem 2</p>
+                <p class="hover:underline decoration-sky-500 decoration-2" >Gun Mayhem 2</p>
             </a>
 
             <a href="/games/hobo2" class="game-tile">
@@ -56,7 +56,7 @@ const pageTitle = "Unblocked games";
                     alt="Hobo 2 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Hobo 2</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Hobo 2</p>
             </a>
             <a href="/games/riddle-school2" class="game-tile">
                 <img
@@ -64,7 +64,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 2 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 2</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Riddle School 2</p>
             </a>
             <a href="/games/vex3" class="game-tile">
                 <img
@@ -72,7 +72,7 @@ const pageTitle = "Unblocked games";
                     alt="Vex 3 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Vex 3</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Vex 3</p>
             </a>
             <a href="/games/tetris" class="game-tile">
                 <img
@@ -80,7 +80,7 @@ const pageTitle = "Unblocked games";
                     alt="Tetris cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Tetris</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Tetris</p>
             </a>
             <a href="/games/theimpossiblequiz2" class="game-tile">
                 <img
@@ -88,7 +88,7 @@ const pageTitle = "Unblocked games";
                     alt="The Impossible Quiz 2 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">The Impossible Quiz 2</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">The Impossible Quiz 2</p>
             </a>
             <a href="/games/supermarioflash" class="game-tile">
                 <img
@@ -96,7 +96,7 @@ const pageTitle = "Unblocked games";
                     alt="Super Mario Flash cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Super Mario Flash</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Super Mario Flash</p>
             </a>
             <a href="/games/minesweeper" class="game-tile">
                 <img
@@ -104,7 +104,7 @@ const pageTitle = "Unblocked games";
                     alt="Minesweeper cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Minesweeper</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Minesweeper</p>
             </a>
             <a href="/games/bloonstd5" class="game-tile">
                 <img
@@ -112,7 +112,7 @@ const pageTitle = "Unblocked games";
                     alt="Bloons TD 5 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Bloons TD 5</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Bloons TD 5</p>
             </a>
             <a href="/games/hobo7" class="game-tile">
                 <img
@@ -120,7 +120,7 @@ const pageTitle = "Unblocked games";
                     alt="Hobo 7 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Hobo 7</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Hobo 7</p>
             </a>
             <a href="/games/doom" class="game-tile">
                 <img
@@ -128,7 +128,7 @@ const pageTitle = "Unblocked games";
                     alt="Doom cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Doom</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Doom</p>
             </a>
             <a href="/games/happywheels" class="game-tile">
                 <img
@@ -136,7 +136,7 @@ const pageTitle = "Unblocked games";
                     alt="Happy Wheels cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Happy Wheels</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Happy Wheels</p>
             </a>
             <a href="/games/geometry-dash" class="game-tile">
                 <img
@@ -144,7 +144,7 @@ const pageTitle = "Unblocked games";
                     alt="Geometry Dash cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Geometry Dash</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Geometry Dash</p>
             </a>
             <a href="/games/madness-project-nexus" class="game-tile">
                 <img
@@ -152,7 +152,7 @@ const pageTitle = "Unblocked games";
                     alt="Madness: Project Nexus cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Madness: Project Nexus</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Madness: Project Nexus</p>
             </a>
             <a href="/games/riddle-school3" class="game-tile">
                 <img
@@ -160,7 +160,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 3 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 3</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Riddle School 3</p>
             </a>
             <a href="/games/riddle-school4" class="game-tile">
                 <img
@@ -168,7 +168,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 4 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 4</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Riddle School 4</p>
             </a>
             <a href="/games/riddle-school5" class="game-tile">
                 <img
@@ -176,7 +176,7 @@ const pageTitle = "Unblocked games";
                     alt="Riddle School 5 cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 5</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Riddle School 5</p>
             </a>
             <a href="/games/plants-vs-zombies" class="game-tile">
                 <img
@@ -184,7 +184,7 @@ const pageTitle = "Unblocked games";
                     alt="Plants vs Zombies cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Plants vs Zombies</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Plants vs Zombies</p>
             </a>
             <a href="/games/geography-game" class="game-tile">
                 <img
@@ -192,7 +192,7 @@ const pageTitle = "Unblocked games";
                     alt="Geography Game cover image"
                     class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
-                <p class="hover:underline decoration-sky-500 decoration-3">Geography Game USA</p>
+                <p class="hover:underline decoration-sky-500 decoration-2">Geography Game USA</p>
             </a>
         </div>
         <div

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,6 +28,8 @@ const pageTitle = "Unblocked games";
             text-align: center;
             text-decoration: none;
             margin: 20px;
+            display: inline-block;
+            overflow: hidden;
         }
         </style>
     </head>
@@ -43,7 +45,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/gm2cover.png"
                     alt="Gun mayhem 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3" >Gun Mayhem 2</p>
             </a>
@@ -52,7 +54,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/hobo2cover.jpg"
                     alt="Hobo 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Hobo 2</p>
             </a>
@@ -60,7 +62,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/Riddle-School-2_logo.png"
                     alt="Riddle School 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 2</p>
             </a>
@@ -68,7 +70,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/vex-3cover.jpg"
                     alt="Vex 3 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Vex 3</p>
             </a>
@@ -76,7 +78,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/tetriscover.avif"
                     alt="Tetris cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Tetris</p>
             </a>
@@ -84,7 +86,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/impossiblequiz2cover.jpg"
                     alt="The Impossible Quiz 2 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">The Impossible Quiz 2</p>
             </a>
@@ -92,7 +94,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/supermarioflashcover.png"
                     alt="Super Mario Flash cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Super Mario Flash</p>
             </a>
@@ -100,7 +102,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/minesweepercover.jpg"
                     alt="Minesweeper cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Minesweeper</p>
             </a>
@@ -108,7 +110,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/bloonstd5cover.png"
                     alt="Bloons TD 5 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Bloons TD 5</p>
             </a>
@@ -116,7 +118,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/hobo7cover.webp"
                     alt="Hobo 7 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Hobo 7</p>
             </a>
@@ -124,7 +126,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/doomcover.jpg"
                     alt="Doom cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Doom</p>
             </a>
@@ -132,7 +134,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/happywheelscover.jpeg"
                     alt="Happy Wheels cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Happy Wheels</p>
             </a>
@@ -140,7 +142,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/geometrydashcover.png"
                     alt="Geometry Dash cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Geometry Dash</p>
             </a>
@@ -148,7 +150,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/madness-cover.png"
                     alt="Madness: Project Nexus cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Madness: Project Nexus</p>
             </a>
@@ -156,7 +158,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddle-school-3-cover.jpg"
                     alt="Riddle School 3 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 3</p>
             </a>
@@ -164,7 +166,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddle-school-4-cover.jpg"
                     alt="Riddle School 4 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 4</p>
             </a>
@@ -172,7 +174,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/riddleschool5-cover.jpg"
                     alt="Riddle School 5 cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Riddle School 5</p>
             </a>
@@ -180,7 +182,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/plants-vs-zombies-cover.gif"
                     alt="Plants vs Zombies cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Plants vs Zombies</p>
             </a>
@@ -188,7 +190,7 @@ const pageTitle = "Unblocked games";
                 <img
                     src="/images/geography_game_cover.jpg"
                     alt="Geography Game cover image"
-                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform overflow-hidden"
+                    class="cover-img rounded-xl hover:scale-105 transition-transform duration-300 hover:shadow-lg active:scale-95 transform"
                 />
                 <p class="hover:underline decoration-sky-500 decoration-3">Geography Game USA</p>
             </a>


### PR DESCRIPTION
- Enhanced game tile display by setting `display: inline-block` and increasing margin from 10px to 20px
- Added interactive animations to all game cover images:
  - Scale effect on hover (hover:scale-105)
  - Shadow effect on hover (hover:shadow-lg)
  - Smooth transitions (transition-transform duration-300)
  - Click feedback animation (active:scale-95 transform)
- Reduced underline decoration thickness from 3 to 2
- Standardized game title capitalization across all games
- Removed unnecessary `<br />` tag after Riddle School 2 cover image